### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 Allow your AI coding agents to access Figma files & prototypes directly.
 You can DM me for any issues / improvements: https://x.com/jasonzhou1993
 
+<a href="https://glama.ai/mcp/servers/pqweyr4aq9">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/pqweyr4aq9/badge" alt="figma-mcp MCP server" />
+</a>
+
 ## Quick Installation with pipx
 
 ```bash
@@ -62,5 +66,3 @@ uv sync
 ```bash
 python -m figma_mcp.main
 ```
-
-


### PR DESCRIPTION
This PR adds a badge for the [figma-mcp](https://glama.ai/mcp/servers/pqweyr4aq9) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/pqweyr4aq9">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/pqweyr4aq9/badge" alt="figma-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.